### PR TITLE
Fix/improved config semantics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -769,9 +769,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openmw-config"
-version = "1.0.5"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba29c2402a093283f70200f571ef4d485a91a133ef5372469ef8464e62f53bf7"
+checksum = "016350068cba3d4d4f93c85448c1ad9d1d34934a56c11bd2813dcb57f88dd849"
 dependencies = [
  "windows-sys",
 ]

--- a/src/app.rs
+++ b/src/app.rs
@@ -72,10 +72,6 @@ impl RunMetadata {
 }
 
 fn selected_config_file_path(config: &openmw_config::OpenMWConfiguration) -> PathBuf {
-    if config.is_user_config() {
-        return config.root_config_file().to_owned();
-    }
-
     config.user_config_path().join("openmw.cfg")
 }
 
@@ -94,13 +90,22 @@ fn explicit_config_path(args: &LightArgs) -> Option<PathBuf> {
         path.to_owned()
     };
 
-    if absolute_path.is_file()
-        || (absolute_path.is_dir() && absolute_path.join("openmw.cfg").is_file())
-    {
-        Some(absolute_path)
-    } else {
-        panic!("Explicit --openmw-cfg must be an openmw.cfg file or a directory containing one");
+    if absolute_path.is_file() {
+        if absolute_path
+            .file_name()
+            .is_some_and(|name| name == "openmw.cfg")
+        {
+            return absolute_path.parent().map(Path::to_owned);
+        }
+
+        panic!("Explicit --openmw-cfg file must be named openmw.cfg");
     }
+
+    if absolute_path.is_dir() && absolute_path.join("openmw.cfg").is_file() {
+        return Some(absolute_path);
+    }
+
+    panic!("Explicit --openmw-cfg must be a directory containing openmw.cfg");
 }
 
 fn load_openmw_config(
@@ -447,19 +452,6 @@ fn backup_openmw_cfg(selected_config_file: &Path) -> io::Result<PathBuf> {
     Ok(backup_path)
 }
 
-fn save_auto_enabled_config(
-    config: &openmw_config::OpenMWConfiguration,
-    selected_config_file: &Path,
-) -> Result<(), openmw_config::ConfigError> {
-    if config.is_user_config()
-        && selected_config_file != config.user_config_path().join("openmw.cfg")
-    {
-        config.save_to_path(selected_config_file)
-    } else {
-        config.save_user()
-    }
-}
-
 fn auto_enable_plugin(
     config: &mut openmw_config::OpenMWConfiguration,
     light_config: &LightConfig,
@@ -489,7 +481,7 @@ fn auto_enable_plugin(
 
     match config.add_content_file(PLUGIN_NAME) {
         Ok(()) => {
-            if let Err(err) = save_auto_enabled_config(config, selected_config_file) {
+            if let Err(err) = config.save_user() {
                 notification_box(
                     "Failed to resave openmw.cfg!",
                     &err.to_string(),
@@ -890,15 +882,12 @@ mod tests {
             NEXT_TEMP_FILE.fetch_add(1, Ordering::Relaxed)
         ));
         std::fs::create_dir(&temp_dir).unwrap();
-        let selected_config = temp_dir.join("custom-openmw.cfg");
+        let selected_config = temp_dir.join("openmw.cfg");
         std::fs::write(&selected_config, "content=Morrowind.esm\n").unwrap();
 
         let backup_path = backup_openmw_cfg(&selected_config).unwrap();
 
-        assert_eq!(
-            backup_path,
-            temp_dir.join("custom-openmw.cfg.s3lightfixes.bak")
-        );
+        assert_eq!(backup_path, temp_dir.join("openmw.cfg.s3lightfixes.bak"));
         assert_eq!(
             std::fs::read_to_string(backup_path).unwrap(),
             "content=Morrowind.esm\n"
@@ -908,44 +897,73 @@ mod tests {
     }
 
     #[test]
-    fn auto_enable_preserves_explicit_custom_config_filename() {
+    fn explicit_openmw_cfg_directory_is_used_as_config_context() {
         let temp_dir = std::env::temp_dir().join(format!(
-            "s3lightfixes-custom-openmw-backup-{}-{}",
+            "s3lightfixes-openmw-dir-{}-{}",
+            std::process::id(),
+            NEXT_TEMP_FILE.fetch_add(1, Ordering::Relaxed)
+        ));
+        std::fs::create_dir(&temp_dir).unwrap();
+        let selected_config = temp_dir.join("openmw.cfg");
+        std::fs::write(&selected_config, "content=Morrowind.esm\n").unwrap();
+        let args = LightArgs::parse_from([
+            "s3lightfixes",
+            "--openmw-cfg",
+            &temp_dir.display().to_string(),
+        ]);
+
+        assert_eq!(explicit_config_path(&args).unwrap(), temp_dir);
+
+        let _ = std::fs::remove_dir_all(temp_dir);
+    }
+
+    #[test]
+    fn explicit_openmw_cfg_file_is_normalized_to_its_directory() {
+        let temp_dir = std::env::temp_dir().join(format!(
+            "s3lightfixes-openmw-file-{}-{}",
+            std::process::id(),
+            NEXT_TEMP_FILE.fetch_add(1, Ordering::Relaxed)
+        ));
+        std::fs::create_dir(&temp_dir).unwrap();
+        let selected_config = temp_dir.join("openmw.cfg");
+        std::fs::write(&selected_config, "content=Morrowind.esm\n").unwrap();
+        let args = LightArgs::parse_from([
+            "s3lightfixes",
+            "--openmw-cfg",
+            &selected_config.display().to_string(),
+        ]);
+
+        assert_eq!(explicit_config_path(&args).unwrap(), temp_dir);
+
+        let _ = std::fs::remove_dir_all(temp_dir);
+    }
+
+    #[test]
+    fn explicit_openmw_cfg_rejects_custom_config_filename() {
+        let temp_dir = std::env::temp_dir().join(format!(
+            "s3lightfixes-openmw-custom-file-{}-{}",
             std::process::id(),
             NEXT_TEMP_FILE.fetch_add(1, Ordering::Relaxed)
         ));
         std::fs::create_dir(&temp_dir).unwrap();
         let selected_config = temp_dir.join("friend-requested.cfg");
         std::fs::write(&selected_config, "content=Morrowind.esm\n").unwrap();
-        let mut openmw_config =
-            openmw_config::OpenMWConfiguration::new(Some(selected_config.clone())).unwrap();
-        let light_config = LightConfig {
-            auto_enable: true,
-            no_notifications: true,
-            ..config()
-        };
+        let args = LightArgs::parse_from([
+            "s3lightfixes",
+            "--openmw-cfg",
+            &selected_config.display().to_string(),
+        ]);
 
-        let selected_config_file = selected_config_file_path(&openmw_config);
-        assert_eq!(selected_config_file, selected_config);
-
-        assert!(auto_enable_plugin(
-            &mut openmw_config,
-            &light_config,
-            &selected_config_file,
-        ));
-
+        let panic = std::panic::catch_unwind(|| explicit_config_path(&args)).unwrap_err();
+        let message = panic
+            .downcast_ref::<&str>()
+            .copied()
+            .or_else(|| panic.downcast_ref::<String>().map(String::as_str))
+            .unwrap();
         assert_eq!(
-            std::fs::read_to_string(temp_dir.join("friend-requested.cfg.s3lightfixes.bak"))
-                .unwrap(),
-            "content=Morrowind.esm\n"
+            message,
+            "Explicit --openmw-cfg file must be named openmw.cfg"
         );
-        assert!(
-            std::fs::read_to_string(&selected_config)
-                .unwrap()
-                .contains("content=S3LightFixes.omwaddon")
-        );
-        assert!(!temp_dir.join("openmw.cfg").exists());
-        assert!(!temp_dir.join("openmw.cfg.s3lightfixes.bak").exists());
 
         let _ = std::fs::remove_dir_all(temp_dir);
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -91,7 +91,12 @@ fn explicit_config_path(args: &LightArgs) -> Option<PathBuf> {
                 .parent()
                 .filter(|parent| !parent.as_os_str().is_empty())
                 .unwrap_or_else(|| Path::new("."));
-            return Some(parent.canonicalize().unwrap_or_else(|_| parent.to_owned()));
+            let config_dir = if parent.is_relative() {
+                parent.canonicalize().unwrap_or_else(|_| parent.to_owned())
+            } else {
+                parent.to_owned()
+            };
+            return Some(config_dir);
         }
 
         panic!("Explicit --openmw-cfg file must be named openmw.cfg");

--- a/src/app.rs
+++ b/src/app.rs
@@ -82,8 +82,10 @@ fn plugin_log_name(plugin_path: &Path) -> String {
     )
 }
 
-fn explicit_config_path(args: &LightArgs) -> Option<PathBuf> {
-    let path = args.openmw_cfg.as_ref()?;
+fn explicit_config_path(args: &LightArgs) -> Result<Option<PathBuf>, String> {
+    let Some(path) = args.openmw_cfg.as_ref() else {
+        return Ok(None);
+    };
 
     if path.is_file() {
         if path.file_name().is_some_and(|name| name == "openmw.cfg") {
@@ -92,34 +94,52 @@ fn explicit_config_path(args: &LightArgs) -> Option<PathBuf> {
                 .filter(|parent| !parent.as_os_str().is_empty())
                 .unwrap_or_else(|| Path::new("."));
             let config_dir = if parent.is_relative() {
-                parent.canonicalize().unwrap_or_else(|_| parent.to_owned())
+                parent.canonicalize().map_err(|error| {
+                    format!(
+                        "Explicit --openmw-cfg path {} could not be resolved: {error}",
+                        parent.display()
+                    )
+                })?
             } else {
                 parent.to_owned()
             };
-            return Some(config_dir);
+            return Ok(Some(config_dir));
         }
 
-        panic!("Explicit --openmw-cfg file must be named openmw.cfg");
+        return Err(format!(
+            "Explicit --openmw-cfg file {} must be named openmw.cfg",
+            path.display()
+        ));
     }
 
-    let absolute_path = if path.is_relative() {
-        path.canonicalize().unwrap_or_else(|_| path.to_owned())
-    } else {
-        path.to_owned()
-    };
+    let absolute_path = path.canonicalize().map_err(|error| {
+        format!(
+            "Explicit --openmw-cfg path {} could not be resolved: {error}",
+            path.display()
+        )
+    })?;
 
     if absolute_path.is_dir() && absolute_path.join("openmw.cfg").is_file() {
-        return Some(absolute_path);
+        return Ok(Some(absolute_path));
     }
 
-    panic!("Explicit --openmw-cfg must be a directory containing openmw.cfg");
+    Err(format!(
+        "Explicit --openmw-cfg path {} must be a directory containing openmw.cfg",
+        path.display()
+    ))
 }
 
 fn load_openmw_config(
     args: &LightArgs,
     no_notifications: bool,
 ) -> openmw_config::OpenMWConfiguration {
-    let loaded_config = if let Some(config_path) = explicit_config_path(args) {
+    let loaded_config = if let Some(config_path) = match explicit_config_path(args) {
+        Ok(config_path) => config_path,
+        Err(error) => {
+            notification_box("Invalid --openmw-cfg path!", &error, no_notifications);
+            exit(127);
+        }
+    } {
         openmw_config::OpenMWConfiguration::new(Some(config_path))
     } else {
         openmw_config::OpenMWConfiguration::from_env_or_user_config()
@@ -919,7 +939,14 @@ mod tests {
             &temp_dir.display().to_string(),
         ]);
 
-        assert_eq!(explicit_config_path(&args).unwrap(), temp_dir);
+        assert_eq!(
+            explicit_config_path(&args)
+                .unwrap()
+                .unwrap()
+                .canonicalize()
+                .unwrap(),
+            temp_dir.canonicalize().unwrap()
+        );
 
         let _ = std::fs::remove_dir_all(temp_dir);
     }
@@ -940,7 +967,7 @@ mod tests {
             &selected_config.display().to_string(),
         ]);
 
-        assert_eq!(explicit_config_path(&args).unwrap(), temp_dir);
+        assert_eq!(explicit_config_path(&args).unwrap().unwrap(), temp_dir);
 
         let _ = std::fs::remove_dir_all(temp_dir);
     }
@@ -961,15 +988,12 @@ mod tests {
             &selected_config.display().to_string(),
         ]);
 
-        let panic = std::panic::catch_unwind(|| explicit_config_path(&args)).unwrap_err();
-        let message = panic
-            .downcast_ref::<&str>()
-            .copied()
-            .or_else(|| panic.downcast_ref::<String>().map(String::as_str))
-            .unwrap();
         assert_eq!(
-            message,
-            "Explicit --openmw-cfg file must be named openmw.cfg"
+            explicit_config_path(&args).unwrap_err(),
+            format!(
+                "Explicit --openmw-cfg file {} must be named openmw.cfg",
+                selected_config.display()
+            )
         );
 
         let _ = std::fs::remove_dir_all(temp_dir);
@@ -994,15 +1018,12 @@ mod tests {
             &symlink_config.display().to_string(),
         ]);
 
-        let panic = std::panic::catch_unwind(|| explicit_config_path(&args)).unwrap_err();
-        let message = panic
-            .downcast_ref::<&str>()
-            .copied()
-            .or_else(|| panic.downcast_ref::<String>().map(String::as_str))
-            .unwrap();
         assert_eq!(
-            message,
-            "Explicit --openmw-cfg file must be named openmw.cfg"
+            explicit_config_path(&args).unwrap_err(),
+            format!(
+                "Explicit --openmw-cfg file {} must be named openmw.cfg",
+                symlink_config.display()
+            )
         );
 
         let _ = std::fs::remove_dir_all(temp_dir);

--- a/src/app.rs
+++ b/src/app.rs
@@ -84,22 +84,24 @@ fn plugin_log_name(plugin_path: &Path) -> String {
 
 fn explicit_config_path(args: &LightArgs) -> Option<PathBuf> {
     let path = args.openmw_cfg.as_ref()?;
+
+    if path.is_file() {
+        if path.file_name().is_some_and(|name| name == "openmw.cfg") {
+            let parent = path
+                .parent()
+                .filter(|parent| !parent.as_os_str().is_empty())
+                .unwrap_or_else(|| Path::new("."));
+            return Some(parent.canonicalize().unwrap_or_else(|_| parent.to_owned()));
+        }
+
+        panic!("Explicit --openmw-cfg file must be named openmw.cfg");
+    }
+
     let absolute_path = if path.is_relative() {
         path.canonicalize().unwrap_or_else(|_| path.to_owned())
     } else {
         path.to_owned()
     };
-
-    if absolute_path.is_file() {
-        if absolute_path
-            .file_name()
-            .is_some_and(|name| name == "openmw.cfg")
-        {
-            return absolute_path.parent().map(Path::to_owned);
-        }
-
-        panic!("Explicit --openmw-cfg file must be named openmw.cfg");
-    }
 
     if absolute_path.is_dir() && absolute_path.join("openmw.cfg").is_file() {
         return Some(absolute_path);
@@ -964,6 +966,97 @@ mod tests {
             message,
             "Explicit --openmw-cfg file must be named openmw.cfg"
         );
+
+        let _ = std::fs::remove_dir_all(temp_dir);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn explicit_openmw_cfg_rejects_custom_filename_symlink_to_openmw_cfg() {
+        let temp_dir = std::env::temp_dir().join(format!(
+            "s3lightfixes-openmw-symlink-file-{}-{}",
+            std::process::id(),
+            NEXT_TEMP_FILE.fetch_add(1, Ordering::Relaxed)
+        ));
+        std::fs::create_dir(&temp_dir).unwrap();
+        let target_config = temp_dir.join("openmw.cfg");
+        let symlink_config = temp_dir.join("friend-requested.cfg");
+        std::fs::write(&target_config, "content=Morrowind.esm\n").unwrap();
+        std::os::unix::fs::symlink(&target_config, &symlink_config).unwrap();
+        let args = LightArgs::parse_from([
+            "s3lightfixes",
+            "--openmw-cfg",
+            &symlink_config.display().to_string(),
+        ]);
+
+        let panic = std::panic::catch_unwind(|| explicit_config_path(&args)).unwrap_err();
+        let message = panic
+            .downcast_ref::<&str>()
+            .copied()
+            .or_else(|| panic.downcast_ref::<String>().map(String::as_str))
+            .unwrap();
+        assert_eq!(
+            message,
+            "Explicit --openmw-cfg file must be named openmw.cfg"
+        );
+
+        let _ = std::fs::remove_dir_all(temp_dir);
+    }
+
+    #[test]
+    fn auto_enable_updates_only_user_config_in_root_chain() {
+        let temp_dir = std::env::temp_dir().join(format!(
+            "s3lightfixes-openmw-root-chain-{}-{}",
+            std::process::id(),
+            NEXT_TEMP_FILE.fetch_add(1, Ordering::Relaxed)
+        ));
+        let root_dir = temp_dir.join("root");
+        let user_dir = temp_dir.join("user");
+        std::fs::create_dir_all(&root_dir).unwrap();
+        std::fs::create_dir_all(&user_dir).unwrap();
+        let root_config = root_dir.join("openmw.cfg");
+        let user_config = user_dir.join("openmw.cfg");
+        std::fs::write(
+            &root_config,
+            format!(
+                "data=/engine/root\nconfig={}\ncontent=RootOnly.esm\n",
+                user_dir.display()
+            ),
+        )
+        .unwrap();
+        std::fs::write(&user_config, "content=Morrowind.esm\n").unwrap();
+        let mut openmw_config =
+            openmw_config::OpenMWConfiguration::new(Some(root_dir.clone())).unwrap();
+        let light_config = LightConfig {
+            auto_enable: true,
+            no_notifications: true,
+            ..config()
+        };
+        let selected_config_file = selected_config_file_path(&openmw_config);
+
+        assert_eq!(selected_config_file, user_config);
+        assert!(auto_enable_plugin(
+            &mut openmw_config,
+            &light_config,
+            &selected_config_file,
+        ));
+
+        assert_eq!(
+            std::fs::read_to_string(&root_config).unwrap(),
+            format!(
+                "data=/engine/root\nconfig={}\ncontent=RootOnly.esm\n",
+                user_dir.display()
+            )
+        );
+        assert_eq!(
+            std::fs::read_to_string(&user_config).unwrap(),
+            "content=Morrowind.esm\ncontent=S3LightFixes.omwaddon\n"
+        );
+        assert_eq!(
+            std::fs::read_to_string(user_dir.join("openmw.cfg.s3lightfixes.bak")).unwrap(),
+            "content=Morrowind.esm\n"
+        );
+        assert!(!root_dir.join("openmw.cfg.s3lightfixes.bak").exists());
 
         let _ = std::fs::remove_dir_all(temp_dir);
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -72,6 +72,10 @@ impl RunMetadata {
 }
 
 fn selected_config_file_path(config: &openmw_config::OpenMWConfiguration) -> PathBuf {
+    if config.is_user_config() {
+        return config.root_config_file().to_owned();
+    }
+
     config.user_config_path().join("openmw.cfg")
 }
 
@@ -443,6 +447,19 @@ fn backup_openmw_cfg(selected_config_file: &Path) -> io::Result<PathBuf> {
     Ok(backup_path)
 }
 
+fn save_auto_enabled_config(
+    config: &openmw_config::OpenMWConfiguration,
+    selected_config_file: &Path,
+) -> Result<(), openmw_config::ConfigError> {
+    if config.is_user_config()
+        && selected_config_file != config.user_config_path().join("openmw.cfg")
+    {
+        config.save_to_path(selected_config_file)
+    } else {
+        config.save_user()
+    }
+}
+
 fn auto_enable_plugin(
     config: &mut openmw_config::OpenMWConfiguration,
     light_config: &LightConfig,
@@ -472,7 +489,7 @@ fn auto_enable_plugin(
 
     match config.add_content_file(PLUGIN_NAME) {
         Ok(()) => {
-            if let Err(err) = config.save_user() {
+            if let Err(err) = save_auto_enabled_config(config, selected_config_file) {
                 notification_box(
                     "Failed to resave openmw.cfg!",
                     &err.to_string(),
@@ -886,6 +903,49 @@ mod tests {
             std::fs::read_to_string(backup_path).unwrap(),
             "content=Morrowind.esm\n"
         );
+
+        let _ = std::fs::remove_dir_all(temp_dir);
+    }
+
+    #[test]
+    fn auto_enable_preserves_explicit_custom_config_filename() {
+        let temp_dir = std::env::temp_dir().join(format!(
+            "s3lightfixes-custom-openmw-backup-{}-{}",
+            std::process::id(),
+            NEXT_TEMP_FILE.fetch_add(1, Ordering::Relaxed)
+        ));
+        std::fs::create_dir(&temp_dir).unwrap();
+        let selected_config = temp_dir.join("friend-requested.cfg");
+        std::fs::write(&selected_config, "content=Morrowind.esm\n").unwrap();
+        let mut openmw_config =
+            openmw_config::OpenMWConfiguration::new(Some(selected_config.clone())).unwrap();
+        let light_config = LightConfig {
+            auto_enable: true,
+            no_notifications: true,
+            ..config()
+        };
+
+        let selected_config_file = selected_config_file_path(&openmw_config);
+        assert_eq!(selected_config_file, selected_config);
+
+        assert!(auto_enable_plugin(
+            &mut openmw_config,
+            &light_config,
+            &selected_config_file,
+        ));
+
+        assert_eq!(
+            std::fs::read_to_string(temp_dir.join("friend-requested.cfg.s3lightfixes.bak"))
+                .unwrap(),
+            "content=Morrowind.esm\n"
+        );
+        assert!(
+            std::fs::read_to_string(&selected_config)
+                .unwrap()
+                .contains("content=S3LightFixes.omwaddon")
+        );
+        assert!(!temp_dir.join("openmw.cfg").exists());
+        assert!(!temp_dir.join("openmw.cfg.s3lightfixes.bak").exists());
 
         let _ = std::fs::remove_dir_all(temp_dir);
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -106,7 +106,7 @@ fn load_openmw_config(
     let loaded_config = if let Some(config_path) = explicit_config_path(args) {
         openmw_config::OpenMWConfiguration::new(Some(config_path))
     } else {
-        openmw_config::OpenMWConfiguration::from_env()
+        openmw_config::OpenMWConfiguration::from_env_or_user_config()
     };
 
     match loaded_config {

--- a/src/light_args.rs
+++ b/src/light_args.rs
@@ -17,7 +17,8 @@ use crate::default;
 #[allow(clippy::struct_excessive_bools)]
 pub struct LightArgs {
     /// Path to openmw.cfg
-    /// By default, uses the system paths defined by:
+    /// By default, uses `OpenMW` root config discovery, falling back to the default user config.
+    /// These paths are defined by:
     /// <https://openmw.readthedocs.io/en/latest/reference/modding/paths.html>
     /// Can be the literal path to an openmw.cfg file (including not literally being called openmw.cfg)
     /// Or the directory in which an openmw.cfg file lives.

--- a/src/light_args.rs
+++ b/src/light_args.rs
@@ -16,12 +16,11 @@ use crate::default;
 // while making the command-line interface and clap mapping pointlessly dishonest.
 #[allow(clippy::struct_excessive_bools)]
 pub struct LightArgs {
-    /// Path to openmw.cfg
+    /// Directory containing openmw.cfg.
     /// By default, uses `OpenMW` root config discovery, falling back to the default user config.
     /// These paths are defined by:
     /// <https://openmw.readthedocs.io/en/latest/reference/modding/paths.html>
-    /// Can be the literal path to an openmw.cfg file (including not literally being called openmw.cfg)
-    /// Or the directory in which an openmw.cfg file lives.
+    /// May also be the literal path to an openmw.cfg file; the filename must be exactly openmw.cfg.
     #[arg(short = 'c', long = "openmw-cfg")]
     pub openmw_cfg: Option<PathBuf>,
 


### PR DESCRIPTION
Better handling of symlinked config locations and remove compatibility for non-openmw.cfg openmw.cfg paths, because it's too semantically fucked to deal with. Also, use newer openmw_config APIs for user config location fallback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation for the `--openmw-cfg` argument with stricter file naming requirements and path normalization.
  * Improved fallback behavior for OpenMW config discovery when no explicit path is provided.

* **Documentation**
  * Clarified help text for the `--openmw-cfg` argument to explain directory-based behavior and accepted file formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->