### PR TITLE
Fix/carryable flag

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -88,7 +88,7 @@ save_config = false
 
 
 # You may also set custom values for light configurations for each light *or* cell record in lightConfig.toml.
-# This allows complete control and customization over all light colors, durations, radii, and animation type(pulse, flicker, etc) in your lightConfig.toml
+# This allows complete control and customization over all light colors, durations, radii, and flags (carryable, pulse, flicker, etc) in your lightConfig.toml
 # Fixed colors use RGB components matching the TES3 Construction Set values: red, green, and blue from 0 to 255. RGB multipliers use red_mult, green_mult, and blue_mult.
 # Color precedence for light overrides: fixed RGB, when present, replaces the source RGB as the base color and disables global HSV fallback for missing HSV components; without fixed RGB, missing HSV components still use the standard/colored global HSV multipliers. HSV fixed fields/multipliers adjust the selected base color per component, fixed and multiplier forms for the same HSV component are mutually exclusive, and RGB multipliers are always applied last.
 # A few examples are shown below.
@@ -113,7 +113,7 @@ duration = 1199.0
 hue_mult = 0.2999999523162842
 red_mult = 1.1
 radius_mult = 1.0
-flag = "PULSESLOW"
+flag = ["CAN_CARRY", "PULSE_SLOW"]
 
 [ambient_overrides."caius cosades' house".ambient]
 red = 64
@@ -218,11 +218,11 @@ Additionally, S3LightFixes will perform the following:
                May be specified multiple times instead of as a separated list.
                Light color values may use fixed RGB fields (`red`, `green`, `blue`), HSV fixed fields (`hue`, `saturation`, `value`), HSV multipliers (`hue_mult`, `saturation_mult`, `value_mult`), and RGB multipliers (`red_mult`, `green_mult`, `blue_mult`).
                EG:
-               --light "Torch_001=radius=255,red=255,green=128,blue=64,hue=220,blue_mult=0.5,duration=1200,flag=FLICKERSLOW" --light "Torch_002=radius_mult=2.0,hue_mult=1.3,red_mult=1.1,duration_mult=5.0,flag=NONE"
+               --light "Torch_001=radius=255,red=255,green=128,blue=64,hue=220,blue_mult=0.5,duration=1200,flag=FLICKER_SLOW" --light "Torch_002=radius_mult=2.0,hue_mult=1.3,red_mult=1.1,duration_mult=5.0,flag=CAN_CARRY|PULSE_SLOW"
                OR
-               --light "Torch_001=radius=255,red=255,green=128,blue=64,hue=220,blue_mult=0.5,duration=1200,flag=FLICKERSLOW:Torch_002=radius_mult=2.0,hue_mult=1.3,red_mult=1.1,duration_mult=5.0,flag=NONE"
+               --light "Torch_001=radius=255,red=255,green=128,blue=64,hue=220,blue_mult=0.5,duration=1200,flag=FLICKER_SLOW:Torch_002=radius_mult=2.0,hue_mult=1.3,red_mult=1.1,duration_mult=5.0,flag=CAN_CARRY|PULSE_SLOW"
                RGB color components are 0-255, matching TES3/Construction Set values. Radius and duration are u32 (can be very big).
-               `flag` controls only animation flags and may be: NONE, FLICKER, FLICKERSLOW, PULSE, PULSESLOW. Other light flags are preserved.
+               `flag` may include: NONE, DYNAMIC, CAN_CARRY, NEGATIVE, FLICKER, FIRE, OFF_BY_DEFAULT, FLICKER_SLOW, PULSE, PULSE_SLOW. Separate multiple CLI flags with `|`; use an array in TOML. This replaces the source light's full flag set.
                Color precedence: fixed RGB, when present, replaces the source RGB as the base color and disables global HSV fallback for missing HSV components; without fixed RGB, missing HSV components still use the standard/colored global HSV multipliers. HSV fixed fields/multipliers adjust the selected base color per component, fixed and multiplier forms for the same HSV component are mutually exclusive, and RGB multipliers are always applied last.
       --ambient <AMBIENT_OVERRIDES>
           

--- a/Readme.md
+++ b/Readme.md
@@ -88,7 +88,7 @@ save_config = false
 
 
 # You may also set custom values for light configurations for each light *or* cell record in lightConfig.toml.
-# This allows complete control and customization over all light colors, durations, radii, and even types(pulse, flicker, etc) in your lightConfig.toml
+# This allows complete control and customization over all light colors, durations, radii, and animation type(pulse, flicker, etc) in your lightConfig.toml
 # Fixed colors use RGB components matching the TES3 Construction Set values: red, green, and blue from 0 to 255. RGB multipliers use red_mult, green_mult, and blue_mult.
 # Color precedence for light overrides: fixed RGB, when present, replaces the source RGB as the base color and disables global HSV fallback for missing HSV components; without fixed RGB, missing HSV components still use the standard/colored global HSV multipliers. HSV fixed fields/multipliers adjust the selected base color per component, fixed and multiplier forms for the same HSV component are mutually exclusive, and RGB multipliers are always applied last.
 # A few examples are shown below.
@@ -222,7 +222,7 @@ Additionally, S3LightFixes will perform the following:
                OR
                --light "Torch_001=radius=255,red=255,green=128,blue=64,hue=220,blue_mult=0.5,duration=1200,flag=FLICKERSLOW:Torch_002=radius_mult=2.0,hue_mult=1.3,red_mult=1.1,duration_mult=5.0,flag=NONE"
                RGB color components are 0-255, matching TES3/Construction Set values. Radius and duration are u32 (can be very big).
-               `flag` may be: NONE, FLICKER, FLICKERSLOW, PULSE, PULSESLOW
+               `flag` controls only animation flags and may be: NONE, FLICKER, FLICKERSLOW, PULSE, PULSESLOW. Other light flags are preserved.
                Color precedence: fixed RGB, when present, replaces the source RGB as the base color and disables global HSV fallback for missing HSV components; without fixed RGB, missing HSV components still use the standard/colored global HSV multipliers. HSV fixed fields/multipliers adjust the selected base color per component, fixed and multiplier forms for the same HSV component are mutually exclusive, and RGB multipliers are always applied last.
       --ambient <AMBIENT_OVERRIDES>
           

--- a/src/light_args.rs
+++ b/src/light_args.rs
@@ -179,11 +179,11 @@ pub struct LightArgs {
      May be specified multiple times instead of as a separated list.
      Light color values may use fixed RGB fields (`red`, `green`, `blue`), HSV fixed fields (`hue`, `saturation`, `value`), HSV multipliers (`hue_mult`, `saturation_mult`, `value_mult`), and RGB multipliers (`red_mult`, `green_mult`, `blue_mult`).
      EG:
-     --light \"Torch_001=radius=255,red=255,green=128,blue=64,hue=220,blue_mult=0.5,duration=1200,flag=FLICKERSLOW\" --light \"Torch_002=radius_mult=2.0,hue_mult=1.3,red_mult=1.1,duration_mult=5.0,flag=NONE\"
+     --light \"Torch_001=radius=255,red=255,green=128,blue=64,hue=220,blue_mult=0.5,duration=1200,flag=FLICKER_SLOW\" --light \"Torch_002=radius_mult=2.0,hue_mult=1.3,red_mult=1.1,duration_mult=5.0,flag=CAN_CARRY|PULSE_SLOW\"
      OR
-     --light \"Torch_001=radius=255,red=255,green=128,blue=64,hue=220,blue_mult=0.5,duration=1200,flag=FLICKERSLOW:Torch_002=radius_mult=2.0,hue_mult=1.3,red_mult=1.1,duration_mult=5.0,flag=NONE\"
+     --light \"Torch_001=radius=255,red=255,green=128,blue=64,hue=220,blue_mult=0.5,duration=1200,flag=FLICKER_SLOW:Torch_002=radius_mult=2.0,hue_mult=1.3,red_mult=1.1,duration_mult=5.0,flag=CAN_CARRY|PULSE_SLOW\"
      RGB color components are 0-255, matching TES3/Construction Set values. Radius and duration are u32 (can be very big).
-     `flag` controls only animation flags and may be: NONE, FLICKER, FLICKERSLOW, PULSE, PULSESLOW. Other light flags are preserved.
+     `flag` may include: NONE, DYNAMIC, CAN_CARRY, NEGATIVE, FLICKER, FIRE, OFF_BY_DEFAULT, FLICKER_SLOW, PULSE, PULSE_SLOW. Separate multiple flags with `|`. This replaces the source light's full flag set.
      Color precedence: fixed RGB, when present, replaces the source RGB as the base color and disables global HSV fallback for missing HSV components; without fixed RGB, missing HSV components still use the standard/colored global HSV multipliers. HSV fixed fields/multipliers adjust the selected base color per component, fixed and multiplier forms for the same HSV component are mutually exclusive, and RGB multipliers are always applied last."),
     )]
     pub light_overrides: Vec<(String, crate::CustomLightData)>,

--- a/src/light_args.rs
+++ b/src/light_args.rs
@@ -183,7 +183,7 @@ pub struct LightArgs {
      OR
      --light \"Torch_001=radius=255,red=255,green=128,blue=64,hue=220,blue_mult=0.5,duration=1200,flag=FLICKERSLOW:Torch_002=radius_mult=2.0,hue_mult=1.3,red_mult=1.1,duration_mult=5.0,flag=NONE\"
      RGB color components are 0-255, matching TES3/Construction Set values. Radius and duration are u32 (can be very big).
-     `flag` may be: NONE, FLICKER, FLICKERSLOW, PULSE, PULSESLOW
+     `flag` controls only animation flags and may be: NONE, FLICKER, FLICKERSLOW, PULSE, PULSESLOW. Other light flags are preserved.
      Color precedence: fixed RGB, when present, replaces the source RGB as the base color and disables global HSV fallback for missing HSV components; without fixed RGB, missing HSV components still use the standard/colored global HSV multipliers. HSV fixed fields/multipliers adjust the selected base color per component, fixed and multiplier forms for the same HSV component are mutually exclusive, and RGB multipliers are always applied last."),
     )]
     pub light_overrides: Vec<(String, crate::CustomLightData)>,

--- a/src/light_override.rs
+++ b/src/light_override.rs
@@ -761,7 +761,12 @@ pub enum LightFlag {
 
 use tes3::esp::LightFlags;
 impl LightFlag {
-    pub fn to_esp_flag(&self) -> LightFlags {
+    const ANIMATION_FLAGS: LightFlags = LightFlags::FLICKER
+        .union(LightFlags::FLICKER_SLOW)
+        .union(LightFlags::PULSE)
+        .union(LightFlags::PULSE_SLOW);
+
+    fn to_animation_flags(&self) -> LightFlags {
         match &self {
             Self::Flicker => LightFlags::FLICKER,
             Self::FlickerSlow => LightFlags::FLICKER_SLOW,
@@ -769,6 +774,19 @@ impl LightFlag {
             Self::PulseSlow => LightFlags::PULSE_SLOW,
             Self::None => LightFlags::empty(),
         }
+    }
+
+    /// Converts this legacy animation override to its TES3 light flag bits.
+    ///
+    /// This intentionally returns only the flicker/pulse subset. Use [`Self::apply_to`] when
+    /// mutating an existing light so non-animation flags such as `CAN_CARRY` are preserved.
+    pub fn to_esp_flag(&self) -> LightFlags {
+        self.to_animation_flags()
+    }
+
+    pub fn apply_to(&self, flags: &mut LightFlags) {
+        flags.remove(Self::ANIMATION_FLAGS);
+        flags.insert(self.to_esp_flag());
     }
 }
 

--- a/src/light_override.rs
+++ b/src/light_override.rs
@@ -2,10 +2,12 @@ use std::{fmt, str::FromStr};
 
 use palette::{Hsv, IntoColor, rgb::Srgb};
 use serde::{Deserialize, Serialize, ser::SerializeStruct};
+use tes3::esp::LightFlags;
 
 #[derive(Debug)]
 pub enum ParseLightError {
     ExclusiveFields(&'static str, &'static str),
+    ConflictingLightFlags(&'static str, &'static str),
     IncompleteRgb,
     BadPair(String),
     UnknownField(String),
@@ -17,8 +19,8 @@ pub enum ParseLightError {
 impl std::fmt::Display for ParseLightError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use ParseLightError::{
-            BadNumber, BadPair, ExclusiveFields, IncompleteRgb, MissingPrefix, UnknownField,
-            UnknownVariant,
+            BadNumber, BadPair, ConflictingLightFlags, ExclusiveFields, IncompleteRgb,
+            MissingPrefix, UnknownField, UnknownVariant,
         };
         match self {
             BadPair(s) => write!(f, "Expected key=value pair, got: `{s}`"),
@@ -26,13 +28,15 @@ impl std::fmt::Display for ParseLightError {
                 f,
                 "Key {existing_field} is mutually exclusive with {bad_field}"
             ),
+            ConflictingLightFlags(existing_flag, bad_flag) => write!(
+                f,
+                "Light flag `{existing_flag}` cannot be combined with `{bad_flag}`"
+            ),
             IncompleteRgb => write!(f, "RGB overrides must specify red, green, and blue"),
             UnknownField(k) => write!(f, "Unknown field: `{k}`"),
             BadNumber(field, e) => write!(f, "Invalid number for `{field}`: {e}"),
             MissingPrefix => write!(f, "Missing type prefix (e.g., `Fixed:` or `Mult:`)"),
-            UnknownVariant(v) => {
-                write!(f, "Unknown light type: `{v}` (expected `Fixed` or `Mult`)")
-            }
+            UnknownVariant(v) => write!(f, "Unknown light flag: `{v}`"),
         }
     }
 }
@@ -744,49 +748,19 @@ impl FromStr for CustomCellAmbient {
     }
 }
 
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
-pub enum LightFlag {
-    #[serde(rename = "FLICKERSLOW")]
-    FlickerSlow,
-    #[serde(rename = "FLICKER")]
-    Flicker,
-    #[serde(rename = "PULSE")]
-    Pulse,
-    #[serde(rename = "PULSESLOW")]
-    PulseSlow,
-    #[default]
-    #[serde(rename = "NONE")]
-    None,
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct LightFlag {
+    flags: LightFlags,
 }
 
-use tes3::esp::LightFlags;
 impl LightFlag {
-    const ANIMATION_FLAGS: LightFlags = LightFlags::FLICKER
-        .union(LightFlags::FLICKER_SLOW)
-        .union(LightFlags::PULSE)
-        .union(LightFlags::PULSE_SLOW);
-
-    fn to_animation_flags(&self) -> LightFlags {
-        match &self {
-            Self::Flicker => LightFlags::FLICKER,
-            Self::FlickerSlow => LightFlags::FLICKER_SLOW,
-            Self::Pulse => LightFlags::PULSE,
-            Self::PulseSlow => LightFlags::PULSE_SLOW,
-            Self::None => LightFlags::empty(),
-        }
+    pub const fn from_esp_flags(flags: LightFlags) -> Self {
+        Self { flags }
     }
 
-    /// Converts this legacy animation override to its TES3 light flag bits.
-    ///
-    /// This intentionally returns only the flicker/pulse subset. Use [`Self::apply_to`] when
-    /// mutating an existing light so non-animation flags such as `CAN_CARRY` are preserved.
-    pub fn to_esp_flag(&self) -> LightFlags {
-        self.to_animation_flags()
-    }
-
-    pub fn apply_to(&self, flags: &mut LightFlags) {
-        flags.remove(Self::ANIMATION_FLAGS);
-        flags.insert(self.to_esp_flag());
+    /// Converts this config override to its TES3 light flag bits.
+    pub fn to_esp_flag(self) -> LightFlags {
+        self.flags
     }
 }
 
@@ -794,15 +768,136 @@ impl FromStr for LightFlag {
     type Err = ParseLightError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_ascii_lowercase().as_str() {
-            "flicker" => Ok(LightFlag::Flicker),
-            "flickerslow" => Ok(LightFlag::FlickerSlow),
-            "pulse" => Ok(LightFlag::Pulse),
-            "pulseslow" => Ok(LightFlag::PulseSlow),
-            "none" => Ok(LightFlag::None),
-            _ => Err(ParseLightError::UnknownVariant(s.to_string())),
+        parse_light_flags(s).map(Self::from_esp_flags)
+    }
+}
+
+impl Serialize for LightFlag {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let names = light_flag_names(self.flags);
+        match names.as_slice() {
+            [] => serializer.serialize_str("NONE"),
+            [name] => serializer.serialize_str(name),
+            _ => {
+                use serde::ser::SerializeSeq;
+
+                let mut seq = serializer.serialize_seq(Some(names.len()))?;
+                for name in names {
+                    seq.serialize_element(name)?;
+                }
+                seq.end()
+            }
         }
     }
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum RawLightFlag {
+    One(String),
+    Many(Vec<String>),
+}
+
+impl<'de> Deserialize<'de> for LightFlag {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let raw = RawLightFlag::deserialize(deserializer)?;
+        let flags = match raw {
+            RawLightFlag::One(flag) => parse_light_flags(&flag),
+            RawLightFlag::Many(flags) => parse_light_flag_tokens(flags.iter().map(String::as_str)),
+        }
+        .map_err(serde::de::Error::custom)?;
+
+        Ok(Self::from_esp_flags(flags))
+    }
+}
+
+fn parse_light_flags(s: &str) -> Result<LightFlags, ParseLightError> {
+    if s.split('|').any(|raw_flag| raw_flag.trim().is_empty()) {
+        return Err(ParseLightError::UnknownVariant(s.to_owned()));
+    }
+
+    parse_light_flag_tokens(s.split('|'))
+}
+
+fn parse_light_flag_tokens<'a>(
+    raw_flags: impl IntoIterator<Item = &'a str>,
+) -> Result<LightFlags, ParseLightError> {
+    let mut flags = LightFlags::empty();
+    let mut parsed_any = false;
+    let mut has_none = false;
+    let mut has_real_flag = false;
+
+    for raw_flag in raw_flags.into_iter().map(str::trim) {
+        if raw_flag.is_empty() {
+            return Err(ParseLightError::UnknownVariant(raw_flag.to_owned()));
+        }
+        parsed_any = true;
+        let flag = parse_light_flag(raw_flag)?;
+        if flag.is_empty() {
+            has_none = true;
+        } else {
+            has_real_flag = true;
+            flags.insert(flag);
+        }
+        if has_none && has_real_flag {
+            return Err(ParseLightError::ConflictingLightFlags(
+                "NONE",
+                "other light flags",
+            ));
+        }
+    }
+
+    if parsed_any {
+        Ok(flags)
+    } else {
+        Err(ParseLightError::UnknownVariant(String::new()))
+    }
+}
+
+fn parse_light_flag(s: &str) -> Result<LightFlags, ParseLightError> {
+    let normalized = s.trim().to_ascii_uppercase();
+
+    match normalized.as_str() {
+        "NONE" => Ok(LightFlags::empty()),
+        "DYNAMIC" => Ok(LightFlags::DYNAMIC),
+        "CAN_CARRY" => Ok(LightFlags::CAN_CARRY),
+        "NEGATIVE" => Ok(LightFlags::NEGATIVE),
+        "FLICKER" => Ok(LightFlags::FLICKER),
+        "FIRE" => Ok(LightFlags::FIRE),
+        "OFF_BY_DEFAULT" => Ok(LightFlags::OFF_BY_DEFAULT),
+        "FLICKER_SLOW" => Ok(LightFlags::FLICKER_SLOW),
+        "PULSE" => Ok(LightFlags::PULSE),
+        "PULSE_SLOW" => Ok(LightFlags::PULSE_SLOW),
+        _ => Err(ParseLightError::UnknownVariant(s.to_owned())),
+    }
+}
+
+fn light_flag_names(flags: LightFlags) -> Vec<&'static str> {
+    let mut names = Vec::new();
+
+    for (flag, name) in [
+        (LightFlags::DYNAMIC, "DYNAMIC"),
+        (LightFlags::CAN_CARRY, "CAN_CARRY"),
+        (LightFlags::NEGATIVE, "NEGATIVE"),
+        (LightFlags::FLICKER, "FLICKER"),
+        (LightFlags::FIRE, "FIRE"),
+        (LightFlags::OFF_BY_DEFAULT, "OFF_BY_DEFAULT"),
+        (LightFlags::FLICKER_SLOW, "FLICKER_SLOW"),
+        (LightFlags::PULSE, "PULSE"),
+        (LightFlags::PULSE_SLOW, "PULSE_SLOW"),
+    ] {
+        if flags.contains(flag) {
+            names.push(name);
+        }
+    }
+
+    names
 }
 
 #[cfg(test)]
@@ -812,7 +907,7 @@ mod tests {
     #[test]
     fn parses_cli_light_override_fixed_fields() {
         let (id, data) = parse_light_override(
-            "Torch_001=radius=255,duration=1200,red=10,green=20,blue=30,flag=FLICKERSLOW",
+            "Torch_001=radius=255,duration=1200,red=10,green=20,blue=30,flag=FLICKER_SLOW",
         )
         .unwrap();
 
@@ -820,7 +915,7 @@ mod tests {
         assert_eq!(data.radius, Some(255));
         assert_eq!(data.duration, Some(1200.0));
         assert_eq!(data.color, Some([10, 20, 30, 0]));
-        assert!(matches!(data.flag, Some(LightFlag::FlickerSlow)));
+        assert_eq!(data.flag.unwrap().to_esp_flag(), LightFlags::FLICKER_SLOW);
     }
 
     #[test]
@@ -1060,15 +1155,94 @@ mod tests {
         }
 
         for (raw, expected) in [
-            ("FLICKERSLOW", LightFlag::FlickerSlow),
-            ("FLICKER", LightFlag::Flicker),
-            ("PULSE", LightFlag::Pulse),
-            ("PULSESLOW", LightFlag::PulseSlow),
-            ("NONE", LightFlag::None),
+            ("DYNAMIC", LightFlags::DYNAMIC),
+            ("CAN_CARRY", LightFlags::CAN_CARRY),
+            ("NEGATIVE", LightFlags::NEGATIVE),
+            ("FLICKER", LightFlags::FLICKER),
+            ("FIRE", LightFlags::FIRE),
+            ("OFF_BY_DEFAULT", LightFlags::OFF_BY_DEFAULT),
+            ("FLICKER_SLOW", LightFlags::FLICKER_SLOW),
+            ("PULSE", LightFlags::PULSE),
+            ("PULSE_SLOW", LightFlags::PULSE_SLOW),
+            ("NONE", LightFlags::empty()),
         ] {
             let parsed = toml::from_str::<FlagWrapper>(&format!("flag = '{raw}'")).unwrap();
 
-            assert!(std::mem::discriminant(&parsed.flag) == std::mem::discriminant(&expected));
+            assert_eq!(parsed.flag.to_esp_flag(), expected);
         }
+    }
+
+    #[test]
+    fn toml_light_flag_rejects_legacy_compound_names() {
+        for raw in ["FLICKERSLOW", "PULSESLOW", "CANCARRY", "OFFBYDEFAULT"] {
+            let Err(err) = toml::from_str::<CustomLightData>(&format!("flag = '{raw}'")) else {
+                panic!("accepted legacy flag spelling {raw}");
+            };
+
+            assert!(err.to_string().contains("Unknown light flag"));
+        }
+    }
+
+    #[test]
+    fn toml_light_flag_accepts_flag_arrays() {
+        #[derive(Deserialize)]
+        struct FlagWrapper {
+            flag: LightFlag,
+        }
+
+        let parsed = toml::from_str::<FlagWrapper>("flag = ['CAN_CARRY', 'PULSE_SLOW']").unwrap();
+
+        assert_eq!(
+            parsed.flag.to_esp_flag(),
+            LightFlags::CAN_CARRY | LightFlags::PULSE_SLOW
+        );
+    }
+
+    #[test]
+    fn cli_light_flag_accepts_multiple_real_flag_names() {
+        let (_, data) = parse_light_override("Torch=flag=CAN_CARRY|PULSE_SLOW").unwrap();
+
+        assert_eq!(
+            data.flag.unwrap().to_esp_flag(),
+            LightFlags::CAN_CARRY | LightFlags::PULSE_SLOW
+        );
+    }
+
+    #[test]
+    fn light_flag_rejects_none_combined_with_real_flags() {
+        for raw in ["Torch=flag=NONE|CAN_CARRY", "Torch=flag=CAN_CARRY|NONE"] {
+            let err = parse_light_override(raw).unwrap_err();
+
+            assert!(matches!(err, ParseLightError::ConflictingLightFlags(..)));
+        }
+
+        let err = toml::from_str::<CustomLightData>("flag = ['NONE', 'CAN_CARRY']").unwrap_err();
+
+        assert!(err.to_string().contains("cannot be combined"));
+    }
+
+    #[test]
+    fn cli_light_flag_rejects_undocumented_separators() {
+        for raw in [
+            "Torch=flag=CAN_CARRY+PULSE_SLOW",
+            "Torch=flag=CAN_CARRY;PULSE_SLOW",
+        ] {
+            let err = parse_light_override(raw).unwrap_err();
+
+            assert!(matches!(err, ParseLightError::UnknownVariant(_)));
+        }
+    }
+
+    #[test]
+    fn toml_light_flag_serializes_with_canonical_underscores() {
+        let serialized = toml::to_string(&CustomLightData {
+            flag: Some(LightFlag::from_esp_flags(
+                LightFlags::CAN_CARRY | LightFlags::PULSE_SLOW,
+            )),
+            ..CustomLightData::default()
+        })
+        .unwrap();
+
+        assert!(serialized.contains("flag = [\"CAN_CARRY\", \"PULSE_SLOW\"]"));
     }
 }

--- a/src/light_processing.rs
+++ b/src/light_processing.rs
@@ -206,7 +206,7 @@ pub fn process_light(light_config: &LightConfig, light: &mut tes3::esp::Light) -
         }
 
         if let Some(flag) = &replacement.flag {
-            flag.apply_to(&mut light.data.flags);
+            light.data.flags = flag.to_esp_flag();
         }
     } else {
         apply_plain_hsv_adjustment(
@@ -306,6 +306,10 @@ mod tests {
             duration_mult: 1.0,
             ..LightConfig::default()
         }
+    }
+
+    const fn flag(flags: LightFlags) -> LightFlag {
+        LightFlag::from_esp_flags(flags)
     }
 
     #[test]
@@ -485,14 +489,14 @@ mod tests {
     }
 
     #[test]
-    fn first_matching_light_override_wins_and_flag_replaces_animation_bits_only() {
+    fn first_matching_light_override_wins_and_flag_replacement_is_exact() {
         let mut light_config = config();
         light_config.standard_radius = 10.0;
         light_config.light_regexes.push((
             Regex::new("torch").unwrap(),
             CustomLightData {
                 radius: Some(111),
-                flag: Some(LightFlag::PulseSlow),
+                flag: Some(flag(LightFlags::PULSE_SLOW)),
                 ..CustomLightData::default()
             },
         ));
@@ -500,7 +504,7 @@ mod tests {
             Regex::new("torch_special").unwrap(),
             CustomLightData {
                 radius: Some(222),
-                flag: Some(LightFlag::Flicker),
+                flag: Some(flag(LightFlags::FLICKER)),
                 ..CustomLightData::default()
             },
         ));
@@ -515,19 +519,16 @@ mod tests {
         process_light(&light_config, &mut light);
 
         assert_eq!(light.data.radius, 111);
-        assert_eq!(
-            light.data.flags,
-            LightFlags::CAN_CARRY | LightFlags::FIRE | LightFlags::PULSE_SLOW
-        );
+        assert_eq!(light.data.flags, LightFlags::PULSE_SLOW);
     }
 
     #[test]
-    fn legacy_none_flag_clears_animation_bits_only() {
+    fn none_flag_clears_all_flags() {
         let mut light_config = config();
         light_config.light_regexes.push((
             Regex::new("torch").unwrap(),
             CustomLightData {
-                flag: Some(LightFlag::None),
+                flag: Some(flag(LightFlags::empty())),
                 ..CustomLightData::default()
             },
         ));
@@ -541,16 +542,16 @@ mod tests {
 
         process_light(&light_config, &mut light);
 
-        assert_eq!(light.data.flags, LightFlags::CAN_CARRY | LightFlags::FIRE);
+        assert_eq!(light.data.flags, LightFlags::empty());
     }
 
     #[test]
-    fn legacy_flag_override_preserves_unknown_bits() {
+    fn flag_replacement_strips_source_bits_not_named_by_user() {
         let mut light_config = config();
         light_config.light_regexes.push((
             Regex::new("torch").unwrap(),
             CustomLightData {
-                flag: Some(LightFlag::Pulse),
+                flag: Some(flag(LightFlags::PULSE)),
                 ..CustomLightData::default()
             },
         ));
@@ -565,10 +566,33 @@ mod tests {
 
         process_light(&light_config, &mut light);
 
-        assert!(light.data.flags.contains(unknown_flag));
-        assert!(light.data.flags.contains(LightFlags::CAN_CARRY));
-        assert!(light.data.flags.contains(LightFlags::PULSE));
-        assert!(!light.data.flags.contains(LightFlags::FLICKER));
+        assert_eq!(light.data.flags, LightFlags::PULSE);
+    }
+
+    #[test]
+    fn flag_override_can_insert_carryable_flags() {
+        let mut light_config = config();
+        light_config.light_regexes.push((
+            Regex::new("torch").unwrap(),
+            CustomLightData {
+                flag: Some(flag(LightFlags::CAN_CARRY | LightFlags::PULSE_SLOW)),
+                ..CustomLightData::default()
+            },
+        ));
+        let mut light = light(
+            "torch",
+            30.0,
+            10,
+            10,
+            LightFlags::FIRE | LightFlags::FLICKER,
+        );
+
+        process_light(&light_config, &mut light);
+
+        assert_eq!(
+            light.data.flags,
+            LightFlags::CAN_CARRY | LightFlags::PULSE_SLOW
+        );
     }
 
     #[test]

--- a/src/light_processing.rs
+++ b/src/light_processing.rs
@@ -206,7 +206,7 @@ pub fn process_light(light_config: &LightConfig, light: &mut tes3::esp::Light) -
         }
 
         if let Some(flag) = &replacement.flag {
-            light.data.flags = flag.to_esp_flag();
+            flag.apply_to(&mut light.data.flags);
         }
     } else {
         apply_plain_hsv_adjustment(
@@ -485,7 +485,7 @@ mod tests {
     }
 
     #[test]
-    fn first_matching_light_override_wins_and_flag_replacement_is_exact() {
+    fn first_matching_light_override_wins_and_flag_replaces_animation_bits_only() {
         let mut light_config = config();
         light_config.standard_radius = 10.0;
         light_config.light_regexes.push((
@@ -509,13 +509,66 @@ mod tests {
             30.0,
             10,
             10,
-            LightFlags::FIRE | LightFlags::FLICKER,
+            LightFlags::CAN_CARRY | LightFlags::FIRE | LightFlags::FLICKER,
         );
 
         process_light(&light_config, &mut light);
 
         assert_eq!(light.data.radius, 111);
-        assert_eq!(light.data.flags, LightFlags::PULSE_SLOW);
+        assert_eq!(
+            light.data.flags,
+            LightFlags::CAN_CARRY | LightFlags::FIRE | LightFlags::PULSE_SLOW
+        );
+    }
+
+    #[test]
+    fn legacy_none_flag_clears_animation_bits_only() {
+        let mut light_config = config();
+        light_config.light_regexes.push((
+            Regex::new("torch").unwrap(),
+            CustomLightData {
+                flag: Some(LightFlag::None),
+                ..CustomLightData::default()
+            },
+        ));
+        let mut light = light(
+            "torch",
+            30.0,
+            10,
+            10,
+            LightFlags::CAN_CARRY | LightFlags::FIRE | LightFlags::FLICKER | LightFlags::PULSE_SLOW,
+        );
+
+        process_light(&light_config, &mut light);
+
+        assert_eq!(light.data.flags, LightFlags::CAN_CARRY | LightFlags::FIRE);
+    }
+
+    #[test]
+    fn legacy_flag_override_preserves_unknown_bits() {
+        let mut light_config = config();
+        light_config.light_regexes.push((
+            Regex::new("torch").unwrap(),
+            CustomLightData {
+                flag: Some(LightFlag::Pulse),
+                ..CustomLightData::default()
+            },
+        ));
+        let unknown_flag = LightFlags::from_bits_retain(0x200);
+        let mut light = light(
+            "torch",
+            30.0,
+            10,
+            10,
+            unknown_flag | LightFlags::CAN_CARRY | LightFlags::FLICKER,
+        );
+
+        process_light(&light_config, &mut light);
+
+        assert!(light.data.flags.contains(unknown_flag));
+        assert!(light.data.flags.contains(LightFlags::CAN_CARRY));
+        assert!(light.data.flags.contains(LightFlags::PULSE));
+        assert!(!light.data.flags.contains(LightFlags::FLICKER));
     }
 
     #[test]


### PR DESCRIPTION
Exposes all light flags when editing them in lightConfig.toml so you don't accidentally fuck your shit up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Enhanced README with clearer guidance on configuring light overrides, including control over colors, durations, and behavior flags.
  * Updated CLI argument documentation with improved examples and flag syntax specifications.

* **Configuration Updates**
  * Standardized flag naming conventions and clarified syntax: pipe-separated values for CLI, arrays for configuration files.
  * Added validation to prevent conflicting flag combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->